### PR TITLE
Fixed AniList no English Title Error

### DIFF
--- a/anilistRequests.js
+++ b/anilistRequests.js
@@ -13,6 +13,7 @@ query fetchShow ($page: Int, $perPage: Int, $search: String) {
         }
         media (search: $search, type: ANIME) {
             title {
+                romaji
                 english
             }
             id
@@ -106,6 +107,8 @@ async function getShow(anime) {
         index = 0;
     }
     let showName = media[index].title.english;
+    console.log(media[index].title);
+    if (showName == null) showName = media[index].title.romaji;
     let id = media[index].id;
     let coverImage = media[index].coverImage.extraLarge;
 


### PR DESCRIPTION
Fixed a bug where the application would crash in instances where AniList does not have an English title specified for the requested show.

With this fix, the application will fallback to use the Romaji title if the English title is not listed.
^ In the future version of Anime Dub Schedule (new repo + different stack), this fallback will be complimented by the user's preference.